### PR TITLE
Make entities stringable

### DIFF
--- a/src/Entity/Category.php
+++ b/src/Entity/Category.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: CategoryRepository::class)]
-class Category
+class Category implements \Stringable
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -71,5 +71,10 @@ class Category
         }
 
         return $this;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->getName();
     }
 }

--- a/src/Entity/Trick.php
+++ b/src/Entity/Trick.php
@@ -13,7 +13,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 #[ORM\Entity(repositoryClass: TrickRepository::class)]
 #[UniqueEntity('name')]
 #[ORM\HasLifecycleCallbacks]
-class Trick
+class Trick implements \Stringable
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -246,5 +246,10 @@ class Trick
         $this->updatedAt = $updatedAt;
 
         return $this;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->getName();
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[UniqueEntity(fields: ['username'], message: 'There is already an account with this username')]
 #[UniqueEntity(fields: ['email'], message: 'There is already an account with this email')]
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface, \Stringable
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -208,5 +208,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->passwordResetToken = $passwordResetToken;
 
         return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getUsername() ?? "Anonymous";
     }
 }

--- a/src/Entity/Video.php
+++ b/src/Entity/Video.php
@@ -102,6 +102,6 @@ class Video implements \Stringable
 
     public function __toString(): string
     {
-        return $this->getUrl();
+        return (string) $this->getUrl();
     }
 }


### PR DESCRIPTION
Added a __toString() method to all entities to make debugging easier (this method is used by the Symfony error pages) and to allow for easy usage in Twig template.