### PR TITLE
Add a reusable type and fix route name

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -42,6 +42,8 @@ class AuthController extends AbstractController
 
             $userService->fillInUserEntityFromUserInformationDTO($userInformation, $user);
 
+            $userInformation->eraseCredentials();
+
             $userService->sendVerificationEmail($user);
 
             // Flush after setting the verification token
@@ -195,6 +197,8 @@ class AuthController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $userService->resetPassword($user, $userInformation);
+
+            $userInformation->eraseCredentials();
 
             $entityManager->flush();
 

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -131,7 +131,7 @@ class AuthController extends AbstractController
         name: 'auth.password-reset-step-1',
         methods: ['GET', 'POST'],
     )]
-    public function step1email(
+    public function passwordResetStep1email(
         UserService $userService,
         UserRepository $userRepository,
         EntityManagerInterface $entityManager,
@@ -177,7 +177,7 @@ class AuthController extends AbstractController
         methods: ['GET', 'POST'],
         requirements: ['token' => Requirement::CATCH_ALL],
     )]
-    public function step2password(
+    public function passwordResetStep2password(
         string $token,
         UserRepository $userRepository,
         UserService $userService,

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -57,7 +57,7 @@ class UserController extends AbstractController
                 $this->addFlash(FlashClasses::WARNING, "An issue occurred when saving the profile picture.");
             }
 
-            return $this->redirectToRoute('user');
+            return $this->redirectToRoute('user.index');
         }
 
         return $this->render('user/index.html.twig', [

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -41,6 +41,8 @@ class UserController extends AbstractController
                 $user
             );
 
+            $userInformation->eraseCredentials();
+
             $profilePictureSaved = $userService->saveProfilePicture($userInformation->profilePicture, $user);
 
             if ($userInformation->removeProfilePicture) {

--- a/src/DTO/NewPasswordDTO.php
+++ b/src/DTO/NewPasswordDTO.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\DTO;
+
+use App\Validator\Constraints as AppAssert;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class NewPasswordDTO
+{
+    public function __construct(
+        #[Assert\NotBlank(groups: ['registration', 'password_reset_step_2'])]
+        #[AppAssert\PasswordRequirements([
+            'groups' => ['registration', 'account_update', 'password_reset_step_2']
+        ])]
+        public ?string $password = null,
+    ) {
+    }
+}

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -24,6 +24,7 @@ class Comment
     private ?User $author = null;
 
     #[ORM\Column(type: Types::TEXT)]
+    #[Assert\NotBlank(message: "The message cannot be empty.")]
     private ?string $text = null;
 
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'replies')]

--- a/src/Form/NewPasswordType.php
+++ b/src/Form/NewPasswordType.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Form;
+
+use App\DTO\NewPasswordDTO;
+use App\Validator\Constraints\PasswordRequirements;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class NewPasswordType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('password', RepeatedType::class, [
+                'type' => PasswordType::class,
+                'required' => $options['required'],
+                'invalid_message' => 'The passwords do not match',
+                'first_options' => [
+                    'label' => sprintf('%s (minimum %d characters)', $options['label'], PasswordRequirements::MIN_LENGTH),
+                    'attr' => [
+                        'autocomplete' => 'new-password',
+                        'min' => PasswordRequirements::MIN_LENGTH,
+                        'max' => PasswordRequirements::MAX_LENGTH,
+                    ],
+
+                ],
+                'second_options' => [
+                    'label' => 'Repeat password',
+                    'attr' => [
+                        'autocomplete' => 'new-password',
+                        'min' => PasswordRequirements::MIN_LENGTH,
+                        'max' => PasswordRequirements::MAX_LENGTH,
+                    ],
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => NewPasswordDTO::class,
+            'label' => 'New password',
+            'required' => false,
+        ]);
+
+        $resolver->setAllowedTypes('label', 'string');
+        $resolver->setAllowedTypes('required', 'bool');
+    }
+}

--- a/src/Form/PasswordResetStep2Type.php
+++ b/src/Form/PasswordResetStep2Type.php
@@ -3,10 +3,7 @@
 namespace App\Form;
 
 use App\DTO\UserInformationDTO;
-use App\Validator\Constraints\PasswordRequirements;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
-use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -15,27 +12,9 @@ class PasswordResetStep2Type extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('newPassword', RepeatedType::class, [
-                'type' => PasswordType::class,
+            ->add('newPassword', NewPasswordType::class, [
                 'required' => true,
-                'invalid_message' => 'The passwords do not match',
-                'first_options' => [
-                    'label' => sprintf('Password (minimum %d characters)', PasswordRequirements::MIN_LENGTH),
-                    'attr' => [
-                        'autocomplete' => 'new-password',
-                        'min' => PasswordRequirements::MIN_LENGTH,
-                        'max' => PasswordRequirements::MAX_LENGTH,
-                    ],
-
-                ],
-                'second_options' => [
-                    'label' => 'Repeat password',
-                    'attr' => [
-                        'autocomplete' => 'new-password',
-                        'min' => PasswordRequirements::MIN_LENGTH,
-                        'max' => PasswordRequirements::MAX_LENGTH,
-                    ],
-                ],
+                'label' => 'Password',
             ]);
     }
 

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -3,12 +3,9 @@
 namespace App\Form;
 
 use App\DTO\UserInformationDTO;
-use App\Validator\Constraints\PasswordRequirements;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
-use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -25,27 +22,9 @@ class RegistrationFormType extends AbstractType
             ->add('email', EmailType::class, [
                 'required' => true,
             ])
-            ->add('newPassword', RepeatedType::class, [
-                'type' => PasswordType::class,
-                'required' => false,
-                'invalid_message' => 'The passwords do not match',
-                'first_options' => [
-                    'label' => sprintf('Password (minimum %d characters)', PasswordRequirements::MIN_LENGTH),
-                    'attr' => [
-                        'autocomplete' => 'new-password',
-                        'min' => PasswordRequirements::MIN_LENGTH,
-                        'max' => PasswordRequirements::MAX_LENGTH,
-                    ],
-
-                ],
-                'second_options' => [
-                    'label' => 'Repeat password',
-                    'attr' => [
-                        'autocomplete' => 'new-password',
-                        'min' => PasswordRequirements::MIN_LENGTH,
-                        'max' => PasswordRequirements::MAX_LENGTH,
-                    ],
-                ],
+            ->add('newPassword', NewPasswordType::class, [
+                'required' => true,
+                'label' => 'Password',
             ])
             ->add('agreeTerms', CheckboxType::class, [
                 'mapped' => false,

--- a/src/Form/UserAccountType.php
+++ b/src/Form/UserAccountType.php
@@ -10,7 +10,6 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
-use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -55,27 +54,8 @@ class UserAccountType extends AbstractType
                     'autocomplete' => 'current-password',
                 ],
             ])
-            ->add('newPassword', RepeatedType::class, [
-                'type' => PasswordType::class,
+            ->add('newPassword', NewPasswordType::class, [
                 'required' => false,
-                'invalid_message' => 'The passwords do not match',
-                'first_options' => [
-                    'label' => sprintf('New password (minimum %d characters)', PasswordRequirements::MIN_LENGTH),
-                    'attr' => [
-                        'autocomplete' => 'new-password',
-                        'min' => PasswordRequirements::MIN_LENGTH,
-                        'max' => PasswordRequirements::MAX_LENGTH,
-                    ],
-
-                ],
-                'second_options' => [
-                    'label' => 'Repeat password',
-                    'attr' => [
-                        'autocomplete' => 'new-password',
-                        'min' => PasswordRequirements::MIN_LENGTH,
-                        'max' => PasswordRequirements::MAX_LENGTH,
-                    ],
-                ],
             ]);
     }
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -43,11 +43,11 @@ class UserService
             ->setUsername($userInformation->username)
             ->setEmail($userInformation->email);
 
-        if ($userInformation->newPassword) {
+        if ($userInformation->getNewPassword()) {
             $user->setPassword(
                 $this->userPasswordHasher->hashPassword(
                     $user,
-                    $userInformation->newPassword
+                    $userInformation->getNewPassword()
                 )
             );
         }
@@ -183,7 +183,7 @@ class UserService
         $user->setPassword(
             $this->userPasswordHasher->hashPassword(
                 $user,
-                $userInformation->newPassword
+                $userInformation->getNewPassword()
             )
         );
     }

--- a/src/Validator/Constraints/PasswordRequirements.php
+++ b/src/Validator/Constraints/PasswordRequirements.php
@@ -33,7 +33,6 @@ class PasswordRequirements extends Compound
     protected function getConstraints(array $options): array
     {
         return [
-            new Assert\NotBlank(),
             new Assert\Type('string'),
             new Assert\Length(
                 min: static::MIN_LENGTH,


### PR DESCRIPTION
I added a dedicated "new password" form type that can be reused for the registration, user account and password reset forms.

Also, fixed a route name error in the User controller.